### PR TITLE
AddingPowerSupport_&_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+- amd64
+- ppc64le
 language: go
 go:
 - "1.12.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: go
 go:
 - "1.12.x"
+  arch: amd64
+- "1.12.x"
+  arch: ppc64le
 - master
+  arch: amd64
+- master
+  arch: ppc64le
+  
 matrix:
   allow_failures:
     - go: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+- ppc64le
+- amd64
 language: go
 go:
 - "1.12.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - go: master
   
   fast_finish: true
+  
 branches:
   only:
   - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,11 @@
-arch:
-- ppc64le
-- amd64
 language: go
 go:
 - "1.12.x"
-  arch: amd64
-- "1.12.x"
-  arch: ppc64le
 - master
-  arch: amd64
-- master
-  arch: ppc64le
-  
 matrix:
   allow_failures:
     - go: master
-  
   fast_finish: true
-  
 branches:
   only:
   - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ go:
 matrix:
   allow_failures:
     - go: master
+  
   fast_finish: true
 branches:
   only:


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/archive

Please let me know if you need any further details? or if I am missing any.

Thank You !!